### PR TITLE
Removed pinned versions from requirements.txt (fixes #310)

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -2,20 +2,20 @@
 # dependency==x.x  # we really need this
 # DON'T do it the file will be parsed on deploy
 
-django==1.8.9
-djangorestframework==3.3.2
-django-international==0.0.6
-django-fsm==2.3.0
-django-filter==0.12.0
-djangorestframework-bulk==0.2.1
-django-livefield==2.4.0
+django>=1.8
+djangorestframework>=3.3.0
+django-international
+django-fsm>=2.3.0
+django-filter
+djangorestframework-bulk
+django-livefield
 django-jsonfield==0.9.15
-python-dateutil==2.4.2
-django-model-utils==2.4
-django-annoying==0.8.7
-pytz==2015.7
+python-dateutil
+django-model-utils
+django-annoying
+pytz
 # python-dev is required for xhtml2pdf to work
-xhtml2pdf==0.0.6
-django-xhtml2pdf==0.0.3
-pyvat==1.3.1
-PyPDF2==1.25.1
+xhtml2pdf
+django-xhtml2pdf
+pyvat
+PyPDF2


### PR DESCRIPTION
The only required package version is `django-jsonfield==0.9.15`