### PR TITLE
python manage.py generate_docs --date throws an error

### DIFF
--- a/silver/management/commands/generate_docs.py
+++ b/silver/management/commands/generate_docs.py
@@ -51,8 +51,6 @@ class Command(BaseCommand):
         translation.activate('en-us')
 
         billing_date = options['billing_date']
-        if type( options['billing_date'] ) == StringType:
-            billing_date = date(options['billing_date'])
 
         docs_generator = DocumentsGenerator()
         if options['subscription_id']:

--- a/silver/management/commands/generate_docs.py
+++ b/silver/management/commands/generate_docs.py
@@ -16,6 +16,7 @@
 import logging
 import argparse
 from datetime import datetime as dt
+from types import StringType
 
 from django.core.management.base import BaseCommand
 from django.utils import translation
@@ -28,7 +29,7 @@ logger = logging.getLogger(__name__)
 
 def date(date_str):
     try:
-        return dt.strptime(date_str, "%Y-%m-%d")
+        return dt.strptime(date_str, "%Y-%m-%d").date()
     except ValueError:
         msg = "Not a valid date: '{date_str}'. "\
               "Expected format: YYYY-MM-DD.".format(date_str=date_str)
@@ -49,10 +50,9 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         translation.activate('en-us')
 
-        billing_date = None
-        if options['billing_date']:
-            billing_date = dt.strptime(options['billing_date'],
-                                       '%Y-%m-%d').date()
+        billing_date = options['billing_date']
+        if type( options['billing_date'] ) == StringType:
+            billing_date = date(options['billing_date'])
 
         docs_generator = DocumentsGenerator()
         if options['subscription_id']:

--- a/silver/tests/commands/test_generate_docs.py
+++ b/silver/tests/commands/test_generate_docs.py
@@ -28,7 +28,7 @@ from silver.tests.factories import (SubscriptionFactory, PlanFactory,
                                     MeteredFeatureFactory,
                                     MeteredFeatureUnitsLogFactory,
                                     CustomerFactory, ProviderFactory)
-
+from silver.management.commands.generate_docs import date as generate_docs_date
 
 class TestInvoiceGenerationCommand(TestCase):
     """
@@ -78,8 +78,8 @@ class TestInvoiceGenerationCommand(TestCase):
         """
 
         ## SETUP ##
-        prev_billing_date = '2015-06-04'
-        curr_billing_date = '2015-06-14'  # First day after trial_end
+        prev_billing_date = generate_docs_date('2015-06-04')
+        curr_billing_date = generate_docs_date('2015-06-14')  # First day after trial_end
 
         customer = CustomerFactory.create(sales_tax_percent=Decimal('0.00'))
 
@@ -148,7 +148,7 @@ class TestInvoiceGenerationCommand(TestCase):
             * add the value of the plan for the next month
             => 3 different proformas
         """
-        billing_date = '2015-03-01'
+        billing_date = generate_docs_date('2015-03-01')
 
         customer = CustomerFactory.create(consolidated_billing=False)
         metered_feature = MeteredFeatureFactory(included_units=Decimal('0.00'))
@@ -213,7 +213,7 @@ class TestInvoiceGenerationCommand(TestCase):
         consumed units => 3 different proformas, each containing only the
         plan's value.
         """
-        billing_date = '2015-03-01'
+        billing_date = generate_docs_date('2015-03-01')
 
         customer = CustomerFactory.create(consolidated_billing=False)
         metered_feature = MeteredFeatureFactory(included_units=Decimal('0.00'))
@@ -259,7 +259,7 @@ class TestInvoiceGenerationCommand(TestCase):
             => 1 proforma with all the aforementioned data
         """
 
-        billing_date = '2015-03-01'
+        billing_date = generate_docs_date('2015-03-01')
         subscriptions_cnt = 3
 
         customer = CustomerFactory.create(
@@ -319,7 +319,7 @@ class TestInvoiceGenerationCommand(TestCase):
         consumed metered features.
         """
 
-        billing_date = '2015-03-01'
+        billing_date = generate_docs_date('2015-03-01')
         subscriptions_cnt = 3
 
         customer = CustomerFactory.create(
@@ -372,8 +372,8 @@ class TestInvoiceGenerationCommand(TestCase):
         next month
         """
 
-        prev_billing_date = '2015-02-14'
-        curr_billing_date = '2015-03-02'
+        prev_billing_date = generate_docs_date('2015-02-14')
+        curr_billing_date = generate_docs_date('2015-03-02')
 
         customer = CustomerFactory.create(
             consolidated_billing=False, sales_tax_percent=Decimal('0.00'))
@@ -414,8 +414,8 @@ class TestInvoiceGenerationCommand(TestCase):
         assert proforma.total == plan.amount
 
     def test_prorated_subscription_with_consumed_mfs_overflow(self):
-        prev_billing_date = '2015-02-15'
-        curr_billing_date = '2015-03-02'
+        prev_billing_date = generate_docs_date('2015-02-15')
+        curr_billing_date = generate_docs_date('2015-03-02')
 
         customer = CustomerFactory.create(consolidated_billing=False,
                                           sales_tax_percent=Decimal('0.00'))
@@ -468,7 +468,7 @@ class TestInvoiceGenerationCommand(TestCase):
         assert proforma.proforma_entries.all()[1].prorated is False
 
     def test_subscription_with_trial_without_metered_features_to_draft(self):
-        billing_date = '2015-03-02'
+        billing_date = generate_docs_date('2015-03-02')
 
         plan = PlanFactory.create(interval='month', interval_count=1,
                                   generate_after=120, enabled=True,
@@ -516,7 +516,7 @@ class TestInvoiceGenerationCommand(TestCase):
             assert doc.quantity == 1
 
     def test_subscription_with_trial_with_metered_features_underflow_to_draft(self):
-        billing_date = '2015-03-01'
+        billing_date = generate_docs_date('2015-03-01')
 
         included_units_during_trial = Decimal('5.00')
         metered_feature = MeteredFeatureFactory(
@@ -591,7 +591,7 @@ class TestInvoiceGenerationCommand(TestCase):
             assert doc.quantity == 1
 
     def test_subscription_with_trial_with_metered_features_overflow_to_draft(self):
-        billing_date = '2015-03-01'
+        billing_date = generate_docs_date('2015-03-01')
 
         metered_feature = MeteredFeatureFactory(
             included_units=Decimal('0.00'),
@@ -673,7 +673,7 @@ class TestInvoiceGenerationCommand(TestCase):
             assert doc.quantity == 1
 
     def test_on_trial_with_consumed_units_underflow(self):
-        billing_date = '2015-03-02'
+        billing_date = generate_docs_date('2015-03-02')
 
         customer = CustomerFactory.create(sales_tax_percent=Decimal('0.00'))
 
@@ -719,7 +719,7 @@ class TestInvoiceGenerationCommand(TestCase):
             assert proforma.total == Decimal('0.0000')
 
     def test_on_trial_with_consumed_units_overflow(self):
-        billing_date = '2015-03-02'
+        billing_date = generate_docs_date('2015-03-02')
 
         customer = CustomerFactory.create(sales_tax_percent=Decimal('0.00'))
 
@@ -780,8 +780,8 @@ class TestInvoiceGenerationCommand(TestCase):
         """
 
         ## SETUP ##
-        prev_billing_date = '2015-06-01'
-        curr_billing_date = '2015-06-04'  # First day after trial_end
+        prev_billing_date = generate_docs_date('2015-06-01')
+        curr_billing_date = generate_docs_date('2015-06-04')  # First day after trial_end
 
         customer = CustomerFactory.create(sales_tax_percent=Decimal('0.00'))
 
@@ -853,8 +853,8 @@ class TestInvoiceGenerationCommand(TestCase):
         """
 
         ## SETUP ##
-        prev_billing_date = '2015-06-01'
-        curr_billing_date = '2015-06-04'  # First day after trial_end
+        prev_billing_date = generate_docs_date('2015-06-01')
+        curr_billing_date = generate_docs_date('2015-06-04')  # First day after trial_end
 
         customer = CustomerFactory.create(sales_tax_percent=Decimal('0.00'))
 
@@ -928,8 +928,8 @@ class TestInvoiceGenerationCommand(TestCase):
         """
 
         ## SETUP ##
-        prev_billing_date = '2015-06-01'
-        curr_billing_date = '2015-06-04'  # First day after trial_end
+        prev_billing_date = generate_docs_date('2015-06-01')
+        curr_billing_date = generate_docs_date('2015-06-04')  # First day after trial_end
 
         customer = CustomerFactory.create(sales_tax_percent=Decimal('0.00'))
 
@@ -1003,8 +1003,8 @@ class TestInvoiceGenerationCommand(TestCase):
         """
 
         ## SETUP ##
-        prev_billing_date = '2015-05-20'
-        curr_billing_date = '2015-06-01'
+        prev_billing_date = generate_docs_date('2015-05-20')
+        curr_billing_date = generate_docs_date('2015-06-01')
 
         customer = CustomerFactory.create(sales_tax_percent=Decimal('0.00'))
 
@@ -1044,7 +1044,7 @@ class TestInvoiceGenerationCommand(TestCase):
         assert proforma.total == plan.amount
 
     def test_full_month_with_consumed_units(self):
-        billing_date = '2015-07-01'
+        billing_date = generate_docs_date('2015-07-01')
 
         customer = CustomerFactory.create(sales_tax_percent=Decimal('0.00'))
 
@@ -1090,7 +1090,7 @@ class TestInvoiceGenerationCommand(TestCase):
             assert proforma.total == plan.amount + consumed_mfs_value
 
     def test_full_month_without_consumed_units(self):
-        billing_date = '2015-07-01'
+        billing_date = generate_docs_date('2015-07-01')
 
         customer = CustomerFactory.create(sales_tax_percent=Decimal('0.00'))
 
@@ -1123,7 +1123,7 @@ class TestInvoiceGenerationCommand(TestCase):
             assert proforma.total == plan.amount
 
     def test_gen_proforma_to_issued_state_for_one_provider(self):
-        billing_date = '2015-03-02'
+        billing_date = generate_docs_date('2015-03-02')
 
         customer = CustomerFactory.create(
             consolidated_billing=False, sales_tax_percent=Decimal('0.00'))
@@ -1153,7 +1153,7 @@ class TestInvoiceGenerationCommand(TestCase):
             assert Proforma.objects.get(id=1).state == Proforma.STATES.ISSUED
 
     def test_gen_mixed_states_for_multiple_providers(self):
-        billing_date = '2015-03-02'
+        billing_date = generate_docs_date('2015-03-02')
 
         customer = CustomerFactory.create(
             consolidated_billing=False, sales_tax_percent=Decimal('0.00'))
@@ -1213,9 +1213,9 @@ class TestInvoiceGenerationCommand(TestCase):
         """
 
         ## SETUP ##
-        prev_billing_date = '2015-05-20'
-        random_billing_date = '2015-05-27'
-        curr_billing_date = '2015-06-01'
+        prev_billing_date = generate_docs_date('2015-05-20')
+        random_billing_date = generate_docs_date('2015-05-27')
+        curr_billing_date = generate_docs_date('2015-06-01')
 
         customer = CustomerFactory.create(sales_tax_percent=Decimal('0.00'))
 
@@ -1300,7 +1300,7 @@ class TestInvoiceGenerationCommand(TestCase):
         end_date   = 2015-02-28 -- has consumed units between trial and end_date
         """
 
-        billing_date = '2015-03-01'
+        billing_date = generate_docs_date('2015-03-01')
 
         metered_feature = MeteredFeatureFactory(included_units=Decimal('0.00'))
         plan = PlanFactory.create(interval='month', interval_count=1,
@@ -1377,7 +1377,7 @@ class TestInvoiceGenerationCommand(TestCase):
         trial_end         = 2015-01-08
         last_billing_date = 2015-02-01
         """
-        billing_date = '2015-03-01'
+        billing_date = generate_docs_date('2015-03-01')
 
         metered_feature = MeteredFeatureFactory(included_units=Decimal('0.00'))
         plan = PlanFactory.create(interval='month', interval_count=1,
@@ -1436,7 +1436,7 @@ class TestInvoiceGenerationCommand(TestCase):
         included_units_during_trial.
         """
 
-        billing_date = '2015-03-01'
+        billing_date = generate_docs_date('2015-03-01')
 
         metered_feature = MeteredFeatureFactory(
             included_units=Decimal('0.00'),
@@ -1513,7 +1513,7 @@ class TestInvoiceGenerationCommand(TestCase):
             assert doc.quantity == mf_units_log_after_trial.consumed_units
 
     def test_canceled_subscription_with_trial_and_trial_overflow(self):
-        billing_date = '2015-03-01'
+        billing_date = generate_docs_date( '2015-03-01' )
 
         units_included_during_trial = Decimal('5.00')
         metered_feature = MeteredFeatureFactory(
@@ -1598,7 +1598,7 @@ class TestInvoiceGenerationCommand(TestCase):
             assert doc.quantity == mf_units_log_after_trial.consumed_units
 
     def test_gen_for_single_canceled_subscription(self):
-        billing_date = '2015-01-06'
+        billing_date = generate_docs_date('2015-01-06')
 
         plan = PlanFactory.create(interval=Plan.INTERVALS.MONTH,
                                   interval_count=1, generate_after=120,
@@ -1640,7 +1640,7 @@ class TestInvoiceGenerationCommand(TestCase):
                 assert proforma.total == Decimal('0.0000')
 
     def test_gen_active_and_canceled_selection(self):
-        billing_date = '2015-02-09'
+        billing_date = generate_docs_date('2015-02-09')
 
         plan = PlanFactory.create(interval='month', interval_count=1,
                                   generate_after=120, enabled=True,

--- a/silver/tests/commands/test_generate_docs_args.py
+++ b/silver/tests/commands/test_generate_docs_args.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 
-import datetime as dt
 from decimal import Decimal
 
 from django.core.management import call_command
@@ -28,7 +27,7 @@ from silver.tests.factories import (SubscriptionFactory, PlanFactory,
                                     MeteredFeatureFactory,
                                     MeteredFeatureUnitsLogFactory,
                                     CustomerFactory, ProviderFactory)
-
+from silver.management.commands.generate_docs import date as generate_docs_date
 
 class TestGenerateDocsArguments(TestCase):
     """
@@ -49,8 +48,7 @@ class TestGenerateDocsArguments(TestCase):
         self.output = StringIO()
         self.good_output = 'Done. You can have a Club-Mate now. :)\n'
         self.date_string = '2016-06-01'
-        self.date        = dt.date(2016, 06, 01) 
-
+        self.date =  generate_docs_date(self.date_string)
 
     def setUp(self):
         # Setup simple subscription
@@ -93,7 +91,7 @@ class TestGenerateDocsArguments(TestCase):
 
     def test_generate_docs_date_options(self):
 
-        call_command('generate_docs', billing_date=self.date_string,
+        call_command('generate_docs', billing_date=self.date,
                       stdout=self.output)
 
         assert self.output.getvalue() == self.good_output
@@ -110,7 +108,7 @@ class TestGenerateDocsArguments(TestCase):
     def test_generate_docs_date_sub_options(self):
 
         call_command('generate_docs',
-                      billing_date=self.date_string,
+                      billing_date=self.date,
                       subscription=self.subscription.id,
                       stdout=self.output)
 

--- a/silver/tests/commands/test_generate_docs_args.py
+++ b/silver/tests/commands/test_generate_docs_args.py
@@ -1,0 +1,128 @@
+# Copyright (c) 2016 University of Oxford
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import datetime as dt
+from decimal import Decimal
+
+from django.core.management import call_command
+from django.test import TestCase
+from django.utils.six import StringIO
+from mock import patch, PropertyMock, MagicMock
+from annoying.functions import get_object_or_None
+
+from silver.models import (Proforma, DocumentEntry, Invoice, Subscription,
+                           Customer, Plan)
+from silver.tests.factories import (SubscriptionFactory, PlanFactory,
+                                    MeteredFeatureFactory,
+                                    MeteredFeatureUnitsLogFactory,
+                                    CustomerFactory, ProviderFactory)
+
+
+class TestGenerateDocsArguments(TestCase):
+    """
+    Quick tests to ensure that generate_docs parses any arguments
+    correctly
+
+    Tests:
+        * pass in nothing
+        * pass in date
+        * pass in subscription id
+        * pass in date and subscription id
+
+        TODO: add missing test descriptions
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(TestGenerateDocsArguments, self).__init__(*args, **kwargs)
+        self.output = StringIO()
+        self.good_output = 'Done. You can have a Club-Mate now. :)\n'
+        self.date_string = '2016-06-01'
+        self.date        = dt.date(2016, 06, 01) 
+
+
+    def setUp(self):
+        # Setup simple subscription
+        self.plan = PlanFactory.create(interval=Plan.INTERVALS.MONTH,
+                                       interval_count=1, generate_after=120,
+                                       enabled=True, amount=Decimal('200.00'),
+                                       trial_period_days=0)
+
+        self.subscription = SubscriptionFactory.create(plan=self.plan,
+                                                       start_date=self.date)
+        self.subscription.activate()
+        self.subscription.save()
+
+    def test_generate_docs_no_args(self):
+
+        call_command('generate_docs', stdout=self.output)
+       
+        assert self.output.getvalue() == self.good_output
+
+    def test_generate_docs_subscription(self):
+
+        call_command('generate_docs', '--subscription=%s' % self.subscription.id,
+                      stdout=self.output)
+
+        assert self.output.getvalue() == self.good_output
+
+        self.output.close()
+        self.output = StringIO()
+
+        call_command('generate_docs', subscription=self.subscription.id,
+                      stdout=self.output)
+        assert self.output.getvalue() == self.good_output
+
+
+    def test_generate_docs_date(self):
+        
+        plan = PlanFactory.create(interval='month', interval_count=1,
+                                  generate_after=120, enabled=True,
+                                  amount=Decimal('200.00') )
+
+        subscription = SubscriptionFactory.create(plan=plan,
+                                                  start_date=self.date)
+        subscription.activate()
+        subscription.save()
+
+        call_command('generate_docs', '--date=%s' % self.date_string )
+
+        assert self.output.getvalue() == self.good_output
+
+        self.output.close()
+        self.output = StringIO()
+
+        call_command('generate_docs', billing_date=self.date,
+                      stdout=self.output)
+
+        assert self.output.getvalue() == self.good_output
+
+
+    def test_generate_docs_date_sub(self):
+
+        call_command('generate_docs',
+                     '--date=%s' % self.date_string,
+                     '--subscription=%s' % self.subscription.id ) 
+
+        assert self.output.getvalue() == self.good_output
+
+        self.output.close()
+        self.output = StringIO()
+
+        call_command('generate_docs',
+                      billing_date=self.date,
+                      subscription=self.subscription.id,
+                      stdout=self.output)
+
+        assert self.output.getvalue() == self.good_output

--- a/silver/tests/commands/test_generate_docs_args.py
+++ b/silver/tests/commands/test_generate_docs_args.py
@@ -70,58 +70,47 @@ class TestGenerateDocsArguments(TestCase):
        
         assert self.output.getvalue() == self.good_output
 
-    def test_generate_docs_subscription(self):
+    def test_generate_docs_subscription_argparser(self):
 
         call_command('generate_docs', '--subscription=%s' % self.subscription.id,
                       stdout=self.output)
 
         assert self.output.getvalue() == self.good_output
 
-        self.output.close()
-        self.output = StringIO()
+    def test_generate_docs_subscription_options(self):
 
         call_command('generate_docs', subscription=self.subscription.id,
                       stdout=self.output)
         assert self.output.getvalue() == self.good_output
 
 
-    def test_generate_docs_date(self):
+    def test_generate_docs_date_argparser(self):
         
-        plan = PlanFactory.create(interval='month', interval_count=1,
-                                  generate_after=120, enabled=True,
-                                  amount=Decimal('200.00') )
-
-        subscription = SubscriptionFactory.create(plan=plan,
-                                                  start_date=self.date)
-        subscription.activate()
-        subscription.save()
-
-        call_command('generate_docs', '--date=%s' % self.date_string )
-
-        assert self.output.getvalue() == self.good_output
-
-        self.output.close()
-        self.output = StringIO()
-
-        call_command('generate_docs', billing_date=self.date,
+        call_command('generate_docs', '--date=%s' % self.date_string,
                       stdout=self.output)
 
         assert self.output.getvalue() == self.good_output
 
+    def test_generate_docs_date_options(self):
 
-    def test_generate_docs_date_sub(self):
-
-        call_command('generate_docs',
-                     '--date=%s' % self.date_string,
-                     '--subscription=%s' % self.subscription.id ) 
+        call_command('generate_docs', billing_date=self.date_string,
+                      stdout=self.output)
 
         assert self.output.getvalue() == self.good_output
 
-        self.output.close()
-        self.output = StringIO()
+    def test_generate_docs_date_sub_argparser(self):
 
         call_command('generate_docs',
-                      billing_date=self.date,
+                     '--date=%s' % self.date_string,
+                     '--subscription=%s' % self.subscription.id,
+                      stdout=self.output)
+
+        assert self.output.getvalue() == self.good_output
+
+    def test_generate_docs_date_sub_options(self):
+
+        call_command('generate_docs',
+                      billing_date=self.date_string,
                       subscription=self.subscription.id,
                       stdout=self.output)
 


### PR DESCRIPTION
We've been looking at using silver for our charging, and one of the things we wanted to do was simulate 
generating documents over a few months. So we set up some subscriptions, starting on 2016-01-01, and then ran:

```
 python manage.py generate_docs --date=2016-01-01
```
However, instead of offering a caffeinated beverage, we received a trace back:
```
<snip>
  File "/srv/silver/local/lib/python2.7/site-packages/silver/management/commands/generate_docs.py", line 57, in handle
    '%Y-%m-%d').date()
TypeError: must be string, not datetime.datetime
```

This seems to be because when adding the  date command line option in the add_arguments class method, it is converted from a string to a datetime.datetime object by the date function within the silver/management/commands/generate_docs.py module, but the handle method expects  options['billing_date'] to be a string.

This pull request adds a series of tests to check that the generate_docs command parses its arguments correctly, and then fixes the above issue by assuming that options['billing_date'] is either None, a datetime.date object or a string and acting accordingly. (The assumption of the string value may only be required for the test functions in silver/tests/commands/test_generate_docs_args.py; however rather than rewrite all of these, and find out this is required elsewhere, I've gone for the safe/lazy option to leave these tests alone - I'm happy to change the tests and remove the check for an input of string should this be felt a better option).