### PR TITLE
Resolve minor issue creating subscriptions with descriptions

### DIFF
--- a/silver/api/serializers.py
+++ b/silver/api/serializers.py
@@ -89,8 +89,8 @@ class JSONSerializerField(serializers.Field):
         if not data:
             return data
 
-        if (data is not None and not isinstance(data, dict)
-                and not isinstance(data, list)):
+        if (data is not None and not isinstance(data, dict) and
+                not isinstance(data, list)):
                     raise ValidationError("Invalid JSON <{}>".format(data))
         return data
 
@@ -212,7 +212,7 @@ class SubscriptionSerializer(serializers.HyperlinkedModelSerializer):
         model = Subscription
         fields = ('id', 'url', 'plan', 'customer', 'trial_end', 'start_date',
                   'ended_at', 'state', 'reference', 'updateable_buckets',
-                  'meta')
+                  'meta', 'description')
         read_only_fields = ('state', 'updateable_buckets')
 
     def validate(self, attrs):

--- a/silver/tests/spec/test_subscription.py
+++ b/silver/tests/spec/test_subscription.py
@@ -46,6 +46,44 @@ class TestSubscriptionEndpoint(APITestCase):
         }), content_type='application/json')
         assert response.status_code == status.HTTP_201_CREATED
 
+    def test_create_post_subscription_reference(self):
+        plan = PlanFactory.create()
+        customer = CustomerFactory.create()
+
+        plan_url = reverse('plan-detail', kwargs={'pk': plan.pk})
+
+        url = reverse('subscription-list', kwargs={'customer_pk': customer.pk})
+
+        test_reference = 'test reference'
+        response = self.client.post(url, json.dumps({
+            "plan": plan_url,
+            "start_date": '2014-11-19',
+            "reference": test_reference,
+        }), content_type='application/json')
+
+        assert response.status_code == status.HTTP_201_CREATED
+
+        assert response.data["reference"] == test_reference
+
+    def test_create_post_subscription_description(self):
+        plan = PlanFactory.create()
+        customer = CustomerFactory.create()
+
+        plan_url = reverse('plan-detail', kwargs={'pk': plan.pk})
+
+        url = reverse('subscription-list', kwargs={'customer_pk': customer.pk})
+
+        test_description = 'test description'
+        response = self.client.post(url, json.dumps({
+            "plan": plan_url,
+            "start_date": '2014-11-19',
+            "description": test_description,
+        }), content_type='application/json')
+
+        assert response.status_code == status.HTTP_201_CREATED
+
+        assert response.data["description"] == test_description
+
     def test_create_post_subscription_with_invalid_trial_end(self):
         plan = PlanFactory.create()
         customer = CustomerFactory.create()


### PR DESCRIPTION
When creating a subscription with a description, the description was not being saved (and as subscriptions can't be patched other than meta data there was no way of adding this field via the API).

This commit updates:
 * silver/tests/spec/test_subscription.py
   * adding two functions to check that subscriptions created with a reference and description respectively, record this information
 * silver/api/serializers.py
   * fix so JSONSerializerField.to_internal_value that it passes hooks/pre-commit (the script was complaining about 'silver/api/serializers.py:93:17: W503 line break before binary operator', and I've moved the 'and' onto the previous line to resolve this)
   * added 'description' to the list of files in the SubscriptionSerializer so that you can create subscriptions with descriptions

The test to check the reference when adding a subscription is probably
unnecessary (as it worked before), but seems to do no harm.