### PR TITLE
Allow api filtering by multiple references.

### DIFF
--- a/silver/api/filters.py
+++ b/silver/api/filters.py
@@ -15,8 +15,19 @@
 
 from django_filters import (FilterSet, CharFilter, BooleanFilter, DateFilter,
                             NumberFilter)
+from django_filters.fields import Lookup
+
 from silver.models import (MeteredFeature, Subscription, Customer, Provider,
                            Plan, Invoice, Proforma)
+
+
+class MultipleCharFilter(CharFilter):
+    def filter(self, qs, value):
+        if value:
+            value = value.split(',')
+
+        lookup = Lookup(value, 'in')
+        return super(MultipleCharFilter, self).filter(qs, lookup)
 
 
 class MeteredFeaturesFilter(FilterSet):
@@ -28,8 +39,8 @@ class MeteredFeaturesFilter(FilterSet):
 
 
 class SubscriptionFilter(FilterSet):
-    plan = CharFilter(name='plan__name', lookup_type='icontains')
-    reference = CharFilter(name='reference', lookup_type='icontains')
+    plan = CharFilter(name='plan__name', lookup_type='iexact')
+    reference = MultipleCharFilter(name='reference', lookup_type='iexact')
 
     class Meta:
         model = Subscription
@@ -47,7 +58,8 @@ class CustomerFilter(FilterSet):
                                   lookup_type='icontains')
     consolidated_billing = CharFilter(name='consolidated_billing',
                                       lookup_type='icontains')
-    reference = CharFilter(name='customer_reference', lookup_type='icontains')
+    reference = MultipleCharFilter(name='customer_reference',
+                                   lookup_type='iexact')
 
     class Meta:
         model = Customer

--- a/silver/models.py
+++ b/silver/models.py
@@ -47,6 +47,7 @@ from pyvat import is_vat_number_format_valid
 from model_utils import Choices
 
 from silver.utils import next_month, prev_month
+from silver.validators import validate_reference
 
 logger = logging.getLogger(__name__)
 
@@ -315,10 +316,9 @@ class Subscription(models.Model):
         help_text='The date when the subscription ended.'
     )
     reference = models.CharField(
-        max_length=128, blank=True, null=True,
+        max_length=128, blank=True, null=True, validators=[validate_reference],
         help_text="The subscription's reference in an external system."
     )
-
     state = FSMField(
         choices=STATE_CHOICES, max_length=12, default=STATES.INACTIVE,
         protected=True, help_text='The state the subscription is in.'
@@ -1461,7 +1461,7 @@ class Customer(AbstractBillingEntity):
         default=False, help_text='A flag indicating consolidated billing.'
     )
     customer_reference = models.CharField(
-        max_length=256, blank=True, null=True,
+        max_length=256, blank=True, null=True, validators=[validate_reference],
         help_text="It's a reference to be passed between silver and clients. "
                   "It usually points to an account ID."
     )

--- a/silver/tests/factories.py
+++ b/silver/tests/factories.py
@@ -131,6 +131,7 @@ class SubscriptionFactory(factory.django.DjangoModelFactory):
         lambda obj: obj.start_date +\
                         datetime.timedelta(days=obj.plan.trial_period_days)
                     if obj.plan.trial_period_days else None)
+    reference = factory.Sequence(lambda n: "{}".format(n))
     meta = factory.Sequence(lambda n: {"something": [n, n + 1]})
 
     @factory.post_generation

--- a/silver/tests/spec/test_subscription.py
+++ b/silver/tests/spec/test_subscription.py
@@ -215,6 +215,32 @@ class TestSubscriptionEndpoint(APITestCase):
              '<' + full_url + '?page=1; rel="first">, ' +
              '<' + full_url + '?page=2; rel="last">')
 
+    def test_get_subscription_list_reference_filter(self):
+        customer = CustomerFactory.create()
+        subscriptions = SubscriptionFactory.create_batch(3, customer=customer)
+
+        url = reverse('subscription-list',
+                      kwargs={'customer_pk': customer.pk})
+
+        references = [subscription.reference for subscription in subscriptions]
+
+        reference = '?reference=' + references[0]
+        response = self.client.get(url + reference)
+
+        assert len(response.data) == 1
+        assert response.status_code == status.HTTP_200_OK
+
+        reference = '?reference=' + ','.join(references)
+        response = self.client.get(url + reference)
+
+        assert len(response.data) == 3
+        assert response.status_code == status.HTTP_200_OK
+
+        reference = '?reference=' + ','.join(references[:-1]) + ',invalid'
+        response = self.client.get(url + reference)
+        assert len(response.data) == 2
+        assert response.status_code == status.HTTP_200_OK
+
     def test_get_subscription_detail(self):
         subscription = SubscriptionFactory.create()
 

--- a/silver/validators.py
+++ b/silver/validators.py
@@ -1,0 +1,7 @@
+from django.core import validators
+
+
+validate_reference = validators.RegexValidator(
+    regex=r'^[^,]*$',
+    message=u'Reference must not contain commas.'
+)


### PR DESCRIPTION
For example `/customers/1/subscriptions/?reference=1,2,3&state=ended`.