### PR TITLE
Replace manage_transaction with execute_transaction

### DIFF
--- a/payment_processors/braintree_processor/models/payment_processors.py
+++ b/payment_processors/braintree_processor/models/payment_processors.py
@@ -86,8 +86,8 @@ class BraintreeTriggered(PaymentProcessorBase, TriggeredProcessorMixin):
 
     def _update_transaction_status(self, transaction, result_transaction):
         """
-        :param payment_method: A Transaction.
-        :param result_payment_method: A transaction from a braintreeSDK
+        :param transaction: A Transaction.
+        :param result_transaction: A transaction from a braintreeSDK
                                       result(response).
         :description: Updates a given transaction's data with data from a
                       braintreeSDK result payment method.
@@ -200,7 +200,7 @@ class BraintreeTriggered(PaymentProcessorBase, TriggeredProcessorMixin):
 
         return result.is_success
 
-    def manage_transaction(self, transaction):
+    def execute_transaction(self, transaction):
         """
         :param transaction: A Braintree transaction in Initial or Pending state.
         :return: True on success, False on failure.
@@ -218,10 +218,9 @@ class BraintreeTriggered(PaymentProcessorBase, TriggeredProcessorMixin):
                 result_transaction = braintree.Transaction.find(
                     transaction.data['braintree_id']
                 )
+                self._update_transaction_status(transaction, result_transaction)
             except braintree.exceptions.NotFoundError:
                 return False
-
-            self._update_transaction_status(transaction, result_transaction)
 
             return True
 

--- a/payment_processors/braintree_processor/views.py
+++ b/payment_processors/braintree_processor/views.py
@@ -41,7 +41,7 @@ class BraintreeTransactionView(GenericTransactionView):
         # manage the transaction
         payment_processor = payment_method.processor
 
-        if not payment_processor.manage_transaction(transaction):
+        if not payment_processor.execute_transaction(transaction):
             return HttpResponse('Something went wrong!')
 
         return HttpResponse('All is well!')

--- a/silver/management/commands/execute_transactions.py
+++ b/silver/management/commands/execute_transactions.py
@@ -34,7 +34,7 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument(
             '--transactions',
-            help='A list of transaction pks to be managed.',
+            help='A list of transaction pks to be executed.',
             action='store', dest='transactions', type=string_to_list
         )
 
@@ -44,19 +44,19 @@ class Command(BaseCommand):
             if pp.type == PaymentProcessorTypes.Triggered
         ]
 
-        manageable_transactions = Transaction.objects.filter(
+        executable_transactions = Transaction.objects.filter(
             state__in=[Transaction.States.Initial, Transaction.States.Pending],
             payment_method__payment_processor__in=payment_processors
         )
 
         if options['transactions']:
-            manageable_transactions = manageable_transactions.filter(
+            executable_transactions = executable_transactions.filter(
                 pk__in=options['transactions']
             )
 
-        for transaction in manageable_transactions:
+        for transaction in executable_transactions:
             try:
-                transaction.payment_processor.manage_transaction(transaction)
+                transaction.payment_processor.execute_transaction(transaction)
             except Exception:
-                logger.error('Encountered exception while managing transaction '
+                logger.error('Encountered exception while executing transaction '
                              'with id=%s.', transaction.id, exc_info=True)

--- a/silver/models/payment_processors/mixins.py
+++ b/silver/models/payment_processors/mixins.py
@@ -37,7 +37,7 @@ class BaseActionableProcessor(object):
 
         raise NotImplementedError
 
-    def manage_transaction(self, transaction):
+    def execute_transaction(self, transaction):
         """
             Only gets called for initial or pending transactions that point to
             this specific Processor
@@ -59,5 +59,3 @@ class AutomaticProcessorMixin(BaseActionableProcessor):
 
 class TriggeredProcessorMixin(BaseActionableProcessor):
     type = PaymentProcessorTypes.Triggered
-
-

--- a/silver/models/transactions.py
+++ b/silver/models/transactions.py
@@ -226,4 +226,4 @@ def post_transition_callback(sender, instance, name, source, target, **kwargs):
             transaction = create_transaction_for_document(instance)
 
             if transaction:
-                transaction.payment_processor.manage_transaction(transaction)
+                transaction.payment_processor.execute_transaction(transaction)

--- a/silver/tests/integration/test_documents_transactions.py
+++ b/silver/tests/integration/test_documents_transactions.py
@@ -11,7 +11,7 @@ from silver.tests.factories import TransactionFactory, ProformaFactory, \
 
 
 class TriggeredProcessor(PaymentProcessorBase, TriggeredProcessorMixin):
-    def manage_transaction(self, transaction):
+    def execute_transaction(self, transaction):
         pass
 
 
@@ -64,8 +64,8 @@ class TestDocumentsTransactions(TestCase):
         )
         mock_recurring.return_value = True
 
-        mock_manage = MagicMock()
-        with patch.multiple(TriggeredProcessor, manage_transaction=mock_manage):
+        mock_execute = MagicMock()
+        with patch.multiple(TriggeredProcessor, execute_transaction=mock_execute):
             invoice.issue()
 
             transactions = Transaction.objects.filter(
@@ -75,9 +75,9 @@ class TestDocumentsTransactions(TestCase):
 
             transaction = transactions[0]
 
-            self.assertIn(call(transaction), mock_manage.call_args_list)
+            self.assertIn(call(transaction), mock_execute.call_args_list)
 
-            self.assertEqual(mock_manage.call_count, 1)
+            self.assertEqual(mock_execute.call_count, 1)
 
     @override_settings(PAYMENT_PROCESSORS=PAYMENT_PROCESSORS)
     @patch('silver.models.payment_methods.PaymentMethod.is_recurring',
@@ -96,8 +96,8 @@ class TestDocumentsTransactions(TestCase):
         )
         mock_recurring.return_value = False
 
-        mock_manage = MagicMock()
-        with patch.multiple(TriggeredProcessor, manage_transaction=mock_manage):
+        mock_execute = MagicMock()
+        with patch.multiple(TriggeredProcessor, execute_transaction=mock_execute):
             invoice.issue()
 
             transactions = Transaction.objects.filter(
@@ -127,8 +127,8 @@ class TestDocumentsTransactions(TestCase):
         mock_usable.return_value = False
         mock_recurring.return_value = True
 
-        mock_manage = MagicMock()
-        with patch.multiple(TriggeredProcessor, manage_transaction=mock_manage):
+        mock_execute = MagicMock()
+        with patch.multiple(TriggeredProcessor, execute_transaction=mock_execute):
             invoice.issue()
 
             transactions = Transaction.objects.filter(
@@ -160,8 +160,8 @@ class TestDocumentsTransactions(TestCase):
             payment_method=payment_method, invoice=invoice, proforma=proforma
         )
 
-        mock_manage = MagicMock()
-        with patch.multiple(TriggeredProcessor, manage_transaction=mock_manage):
+        mock_execute = MagicMock()
+        with patch.multiple(TriggeredProcessor, execute_transaction=mock_execute):
             invoice.issue()
 
             transactions = Transaction.objects.filter(
@@ -171,4 +171,4 @@ class TestDocumentsTransactions(TestCase):
             self.assertEqual(len(transactions), 1)
             self.assertEqual(transactions[0], transaction)
 
-            self.assertEqual(mock_manage.call_count, 0)
+            self.assertEqual(mock_execute.call_count, 0)


### PR DESCRIPTION
Fixes https://github.com/PressLabs/silver/issues/409
Other than renaming everywhere, I don't see any logic that needs to be moved. The Braintree processor currently changes the transaction state in its own implementation, which is only called from `execute_transaction`.
CR please and let me know if I went about this wrong.